### PR TITLE
Update README with API and web instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ This project implements a Retrieval-Augmented Generation (RAG) chatbot that answ
     ```
 
     The chatbot will load the index and passages, and you can start asking questions in the terminal. To exit, type `exit` or `quit`.
+
+3.  **Run the API server:**
+
+    Start the API version of the chatbot:
+
+    ```bash
+    python chatbot/chatbot.py api
+    ```
+
+4.  **Launch the web interface:**
+
+    Run the PHP built-in server from the `web` directory:
+
+    ```bash
+    cd web
+    php -S localhost:8080
+    ```


### PR DESCRIPTION
## Summary
- document how to run the API server
- add instructions for starting the PHP web interface

## Testing
- `pytest -q` *(fails: Python 3.9.13 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f346dbab083249b739e366e88e3ee