### PR TITLE
Add logging for YouTube transcript fetch

### DIFF
--- a/scraping/scrape_youtube.py
+++ b/scraping/scrape_youtube.py
@@ -31,14 +31,25 @@ def get_all_video_ids(youtube, channel_id):
     return video_ids
 
 def fetch_transcript(video_id):
+    """Return transcript text for the given video or None if unavailable."""
+    print(f"  Fetching transcript for {video_id}…")
     try:
-        transcript = YouTubeTranscriptApi().fetch(video_id)
-        text = ' '.join([seg.text for seg in transcript])
+        tl = YouTubeTranscriptApi.list_transcripts(video_id)
+        transcript = tl.find_transcript(['en']).fetch()
+        text = " ".join(seg["text"] for seg in transcript)
+        print(f"  → fetched {len(transcript)} segments")
         return text
-    except (TranscriptsDisabled, NoTranscriptFound):
+    except (TranscriptsDisabled, NoTranscriptFound) as e:
+        print(f"  → no transcript: {e}")
+        try:
+            tl = YouTubeTranscriptApi.list_transcripts(video_id)
+            langs = [t.language_code for t in tl]
+            print(f"  → available languages: {langs}")
+        except Exception as e2:
+            print(f"  → could not list transcripts: {e2}")
         return None
     except Exception as e:
-        print(f"Error fetching transcript for {video_id}: {e}")
+        print(f"  → error fetching transcript: {e}")
         return None
 
 def main():


### PR DESCRIPTION
## Summary
- improve logging in `scrape_youtube.py` to debug transcript fetching
- use `list_transcripts().find_transcript().fetch()` for clarity

## Testing
- `PYENV_VERSION=3.10.17 python -m py_compile scraping/scrape_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_687f3885a7c48324b54a5f43c4a3ff6c