### PR TITLE
Add Docker configuration for app and database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ IcomQaAi/
 ├── tests/                      # pytest based tests
 │   └── test_endpoints.py
 ├── Dockerfile
+├── docker-compose.yml
 ├── requirements.txt
 └── README.md
 ```
@@ -35,16 +36,29 @@ IcomQaAi/
 2. Set the required environment variables:
 
    ```bash
-   export DATABASE_URL=postgresql://user:password@localhost:5432/icom
+   export DATABASE_URL=postgresql://user:password@localhost:5433/icomqaai
    export OPENAI_API_KEY=your-key
    export YOUTUBE_API_KEY=your-key
    ```
 
 3. Run the server:
 
-   ```bash
-   uvicorn app.main:app --reload
-   ```
+    ```bash
+    uvicorn app.main:app --reload
+    ```
+
+## Docker
+
+Start the API and a PostgreSQL database with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The API will be available at <http://localhost:8000>.
+
+The PostgreSQL database is exposed on port `5433` with the default database
+name `icomqaai`.
 
 ## Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: icomqaai
+    ports:
+      - "5433:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  app:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/icomqaai
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize FastAPI app
- create docker-compose.yml to run app with PostgreSQL
- document Docker usage in README
- update database port to 5433 and default name to icomqaai to avoid conflicts

## Testing
- `pytest` *(fails: pyenv: version `3.11.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c01812c7c08324806132d40a545f8a