### PR TITLE
Add Postgres health check for app startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,17 @@ services:
       - "5433:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   app:
     build: .
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/icomqaai
     ports:


### PR DESCRIPTION
## Summary
- ensure Postgres is ready before launching FastAPI service

## Testing
- `pytest` *(fails: pyenv: version `3.11.7` is not installed (set by /workspace/IcomQaAi/.python-version))*

------
https://chatgpt.com/codex/tasks/task_e_68c0224ee2dc832482375d432451e608