### PR TITLE
Add session tracking to chat endpoints

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -73,7 +73,8 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), bot: RAGChatbot = Depe
                                      context=retrieved,
                                      history=req.history,
                                      tokens_sent=tokens_sent,
-                                     tokens_received=tokens_received)
+                                     tokens_received=tokens_received,
+                                     session_id=req.session_id)
     db.add(entry)
     db.commit()
     return ChatResponse(response=answer)
@@ -104,7 +105,8 @@ async def chat_stream(req: ChatRequest, db: Session = Depends(get_db), bot: RAGC
             context=retrieved,
             history=req.history,
             tokens_sent=tokens_sent,
-            tokens_received=tokens_received
+            tokens_received=tokens_received,
+            session_id=req.session_id
         ))
         db.commit()
         # Send a final empty message to signal completion

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -39,6 +39,7 @@ class CustomerSupportChatbotAI(Base):
     history = Column(Text, nullable=True)
     tokens_sent = Column(Integer, nullable=True)
     tokens_received = Column(Integer, nullable=True)
+    session_id = Column(String, nullable=False)
     date_asked = Column(DateTime, default=datetime.now(), nullable=False)
 
 

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -1,22 +1,30 @@
 from pydantic import BaseModel, Field
 from typing import List
 
+
 class ChatRequest(BaseModel):
     history: List[str] = Field(
         default_factory=list,
         example=[
             "איך מנהלים את היומן?",
-            "כדי לנהל את היומן, יש להיכנס ליומן האישי במערכת וללחוץ על הקישור \"ניהול\" בצד שמאל למעלה. שם ניתן להוסיף יומנים נוספים ולעדכן בהם פגישות. ניתן גם לראות יומנים של עובדים אחרים ולנהל את המשימות והאירועים שלהם.\n\nלפרטים נוספים, ראה: https://support.zebracrm.com/%d7%a0%d7%99%d7%94%d7%95%d7%9c-%d7%99%d7%95%d7%9e%d7%9f-%d7%94%d7%95%d7%a1%d7%a4%d7%aa-%d7%99%d7%95%d7%9e%d7%a0%d7%99%d7%9d-%d7%9c%d7%a2%d7%95%d7%91%d7%93/"
+            "כדי לנהל את היומן, יש להיכנס ליומן האישי במערכת וללחוץ על הקישור \"ניהול\" בצד שמאל למעלה. שם ניתן להוסיף יומנים נוספים ולעדכן בהם פגישות. ניתן גם לראות יומנים של עובדים אחרים ולנהל את המשימות והאירועים שלהם.\n\nלפרטים נוספים, ראה: https://support.zebracrm.com/%d7%a0%d7%99%d7%94%d7%95%d7%9c-%d7%99%d7%95%d7%9e%d7%9f-%d7%94%d7%95%d7%a1%d7%a4%d7%aa-%d7%99%d7%95%d7%9e%d7%a0%d7%99%d7%9d-%d7%9c%d7%a2%d7%95%d7%91%d7%93/",
         ],
-        description="List of previous messages in the conversation, alternating between user and assistant"
+        description="List of previous messages in the conversation, alternating between user and assistant",
     )
     message: str = Field(
         example="איך מוסיפים אוטומציה ליומן?",
-        description="The new message from the user"
+        description="The new message from the user",
     )
+    session_id: str = Field(
+        example="abc123",
+        description="Identifier for the user session",
+    )
+
 
 class ChatResponse(BaseModel):
     response: str
 
+
 class OperationResponse(BaseModel):
     amount_added: int
+

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -22,19 +22,13 @@ def patch_services(monkeypatch):
     monkeypatch.setattr("app.services.svc.chat", fake_chat)
 
 
-def test_create_database():
-    res = client.get("/api/v1/create_database")
-    assert res.status_code == 200
-    assert res.json() == {"amount_added": 0}
-
-
-def test_rewrite_database():
-    res = client.get("/api/v1/rewrite_database")
+def test_add_new_data():
+    res = client.get("/api/v1/add_new_data")
     assert res.status_code == 200
     assert res.json() == {"amount_added": 0}
 
 
 def test_chat():
-    res = client.post("/api/v1/chat", json={"message": "hi", "history": []})
+    res = client.post("/api/v1/chat", json={"message": "hi", "history": [], "session_id": "abc"})
     assert res.status_code == 200
     assert res.json() == {"response": "stubbed response"}


### PR DESCRIPTION
## Summary
- add `session_id` field to ChatRequest schema
- persist `session_id` to database and save with chat history
- update tests for new request field and available endpoints

## Testing
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*

------
https://chatgpt.com/codex/tasks/task_e_68c17128c0708324917b8cf3a6faebb1