### PR TITLE
Add support request endpoint and persistence

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -4,16 +4,8 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 import json
 from app.models.db import init_db, SessionLocal
-from sqlalchemy import func
-
 from app.models.db import CustomerSupportChatbotAI, SupportRequest
-from app.schemas.api import (
-    ChatRequest,
-    ChatResponse,
-    OperationResponse,
-    SupportRequestCreate,
-    SupportRequestResponse,
-)
+from app.schemas.api import (ChatRequest, ChatResponse, OperationResponse, SupportRequestCreate, SupportRequestResponse)
 from app.services import svc
 from app.services.rag_chatbot import RAGChatbot
 from app.services.training.rag import RAGTrainer
@@ -89,29 +81,13 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), bot: RAGChatbot = Depe
     db.commit()
     return ChatResponse(response=answer)
 
-
 @router.post("/open_support_request", response_model=SupportRequestResponse)
-def open_support_request(
-    req: SupportRequestCreate, db: Session = Depends(get_db)
-):
-    message_amount = (
-        db.query(func.count(CustomerSupportChatbotAI.id))
-        .filter(CustomerSupportChatbotAI.session_id == req.session_id)
-        .scalar()
-    )
-    support_request = SupportRequest(
-        session_id=req.session_id,
-        message_amount=message_amount or 0,
-    )
+def open_support_request(req: SupportRequestCreate, db: Session = Depends(get_db)):
+    support_request = SupportRequest(session_id=req.session_id)
     db.add(support_request)
     db.commit()
     db.refresh(support_request)
-    return SupportRequestResponse(
-        id=support_request.id,
-        session_id=support_request.session_id,
-        message_amount=support_request.message_amount,
-        date_added=support_request.date_added,
-    )
+    return SupportRequestResponse(id=support_request.id, session_id=support_request.session_id)
 
 @router.post("/chat/stream", response_model=ChatResponse)
 async def chat_stream(req: ChatRequest, db: Session = Depends(get_db), bot: RAGChatbot = Depends(get_bot)):

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -4,8 +4,16 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 import json
 from app.models.db import init_db, SessionLocal
-from app.models.db import CustomerSupportChatbotAI
-from app.schemas.api import ChatRequest, ChatResponse, OperationResponse
+from sqlalchemy import func
+
+from app.models.db import CustomerSupportChatbotAI, SupportRequest
+from app.schemas.api import (
+    ChatRequest,
+    ChatResponse,
+    OperationResponse,
+    SupportRequestCreate,
+    SupportRequestResponse,
+)
 from app.services import svc
 from app.services.rag_chatbot import RAGChatbot
 from app.services.training.rag import RAGTrainer
@@ -80,6 +88,30 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), bot: RAGChatbot = Depe
     db.add(entry)
     db.commit()
     return ChatResponse(response=answer)
+
+
+@router.post("/open_support_request", response_model=SupportRequestResponse)
+def open_support_request(
+    req: SupportRequestCreate, db: Session = Depends(get_db)
+):
+    message_amount = (
+        db.query(func.count(CustomerSupportChatbotAI.id))
+        .filter(CustomerSupportChatbotAI.session_id == req.session_id)
+        .scalar()
+    )
+    support_request = SupportRequest(
+        session_id=req.session_id,
+        message_amount=message_amount or 0,
+    )
+    db.add(support_request)
+    db.commit()
+    db.refresh(support_request)
+    return SupportRequestResponse(
+        id=support_request.id,
+        session_id=support_request.session_id,
+        message_amount=support_request.message_amount,
+        date_added=support_request.date_added,
+    )
 
 @router.post("/chat/stream", response_model=ChatResponse)
 async def chat_stream(req: ChatRequest, db: Session = Depends(get_db), bot: RAGChatbot = Depends(get_bot)):

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -48,7 +48,7 @@ class SupportRequest(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     session_id = Column(String, nullable=False, index=True)
-    date_added = Column(DateTime, server_default=datetime.now(), nullable=False)
+    date_added = Column(DateTime, default=datetime.now(), nullable=False)
 
 
 def init_db() -> None:

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sqlalchemy import Column, Integer, String, Text, DateTime, create_engine
+from sqlalchemy.sql import func
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from app.core.config import settings
@@ -41,6 +42,17 @@ class CustomerSupportChatbotAI(Base):
     tokens_received = Column(Integer, nullable=True)
     session_id = Column(String, nullable=False)
     date_asked = Column(DateTime, default=datetime.now(), nullable=False)
+
+
+class SupportRequest(Base):
+    """Stores customer support requests opened by end-users."""
+
+    __tablename__ = "support_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(String, nullable=False, index=True)
+    date_added = Column(DateTime, server_default=func.now(), nullable=False)
+    message_amount = Column(Integer, nullable=False)
 
 
 def init_db() -> None:

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
-
 from sqlalchemy import Column, Integer, String, Text, DateTime, create_engine
-from sqlalchemy.sql import func
 from sqlalchemy.orm import declarative_base, sessionmaker
-
 from app.core.config import settings
 from datetime import datetime
 
@@ -51,8 +48,7 @@ class SupportRequest(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     session_id = Column(String, nullable=False, index=True)
-    date_added = Column(DateTime, server_default=func.now(), nullable=False)
-    message_amount = Column(Integer, nullable=False)
+    date_added = Column(DateTime, server_default=datetime.now(), nullable=False)
 
 
 def init_db() -> None:

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from pydantic import BaseModel, Field
 from typing import List
 
@@ -14,7 +12,7 @@ class ChatRequest(BaseModel):
         description="List of previous messages in the conversation, alternating between user and assistant",
     )
     message: str = Field(
-        example="איך מוסיפים אוטומציה ליומן?",
+        example="איך מוסיפים מידע ליומן?",
         description="The new message from the user",
     )
     session_id: str = Field(
@@ -41,6 +39,3 @@ class SupportRequestCreate(BaseModel):
 class SupportRequestResponse(BaseModel):
     id: int
     session_id: str
-    message_amount: int
-    date_added: datetime
-

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 from typing import List
 
@@ -27,4 +29,18 @@ class ChatResponse(BaseModel):
 
 class OperationResponse(BaseModel):
     amount_added: int
+
+
+class SupportRequestCreate(BaseModel):
+    session_id: str = Field(
+        example="abc123",
+        description="Identifier for the user session that will be escalated to support",
+    )
+
+
+class SupportRequestResponse(BaseModel):
+    id: int
+    session_id: str
+    message_amount: int
+    date_added: datetime
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,25 +1,51 @@
+import os
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
+TEST_DB_PATH = Path("test.db")
+if TEST_DB_PATH.exists():
+    TEST_DB_PATH.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB_PATH}"
+
 from app.main import app
+from app.models.db import (
+    CustomerSupportChatbotAI,
+    SessionLocal,
+    SupportRequest,
+)
 
 client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
 def patch_services(monkeypatch):
-    def fake_add_data(_):
+    def fake_add_data(db, logger):
         return 0
 
-    def fake_rebuild(_):
+    def fake_rebuild(*_):
         return 0
 
-    def fake_chat(message, history=None):
-        return "stubbed response"
+    def fake_chat(bot, message, history=None):
+        return "stubbed response", "retrieved", 0, 0
 
     monkeypatch.setattr("app.services.svc.add_data", fake_add_data)
     monkeypatch.setattr("app.services.svc.rebuild_database", fake_rebuild)
     monkeypatch.setattr("app.services.svc.chat", fake_chat)
+
+
+@pytest.fixture(autouse=True)
+def clean_database():
+    with SessionLocal() as session:
+        session.query(SupportRequest).delete()
+        session.query(CustomerSupportChatbotAI).delete()
+        session.commit()
+    yield
+    with SessionLocal() as session:
+        session.query(SupportRequest).delete()
+        session.query(CustomerSupportChatbotAI).delete()
+        session.commit()
 
 
 def test_add_new_data():
@@ -32,3 +58,39 @@ def test_chat():
     res = client.post("/api/v1/chat", json={"message": "hi", "history": [], "session_id": "abc"})
     assert res.status_code == 200
     assert res.json() == {"response": "stubbed response"}
+
+
+def test_open_support_request_counts_messages():
+    session_id = "abc"
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                CustomerSupportChatbotAI(
+                    question="q1",
+                    answer="a1",
+                    context="ctx",
+                    history="[]",
+                    tokens_sent=1,
+                    tokens_received=2,
+                    session_id=session_id,
+                ),
+                CustomerSupportChatbotAI(
+                    question="q2",
+                    answer="a2",
+                    context="ctx",
+                    history="[]",
+                    tokens_sent=1,
+                    tokens_received=2,
+                    session_id=session_id,
+                ),
+            ]
+        )
+        session.commit()
+
+    res = client.post("/api/v1/open_support_request", json={"session_id": session_id})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["session_id"] == session_id
+    assert data["message_amount"] == 2
+    assert isinstance(data["id"], int)
+    assert data["date_added"] is not None


### PR DESCRIPTION
## Summary
- add a SQLAlchemy model and API endpoint for persisting support requests
- expose Pydantic schemas and tests for the new endpoint, including message counting logic

## Testing
- PYENV_VERSION=3.11.12 python -m pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68da3efabc10832483d18a49f44f6e22